### PR TITLE
Add support for Mozilla Spidermonkey Shell

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -12,6 +12,7 @@ class Executor(CompiledExecutor):
     ext = '.go'
     name = 'GO'
     address_grace = 786432
+    syscalls = ['pselect6']
     command = 'go'
     test_name = 'echo'
     test_program = '''\

--- a/dmoj/executors/LCODE.py
+++ b/dmoj/executors/LCODE.py
@@ -1,0 +1,20 @@
+from dmoj.executors.base_executor import ScriptExecutor
+
+
+class Executor(ScriptExecutor):
+    name = 'LOLCODE'
+    ext = '.lic'
+    command = 'lci'
+    command_paths = ['lci']
+
+    test_program = '''\
+HAI 1.2
+    CAN HAS STDIO?
+    I HAS A INPUT
+    GIMMEH INPUT
+    VISIBLE INPUT
+KTHXBYE
+'''
+
+    def get_cmdline(self):
+        return ['lci', self._code]

--- a/dmoj/executors/MOZJS.py
+++ b/dmoj/executors/MOZJS.py
@@ -1,0 +1,12 @@
+from .base_executor import ScriptExecutor
+
+
+class Executor(ScriptExecutor):
+    ext = '.js'
+    name = 'MOZJS'
+    command = 'js'
+    test_program = 'print(readline());'
+    nproc = -1
+    @classmethod
+    def get_version_flags(cls, command):
+        return ['-v']

--- a/dmoj/executors/RUBY2.py
+++ b/dmoj/executors/RUBY2.py
@@ -5,8 +5,8 @@ from .ruby_executor import RubyExecutor
 
 class Executor(RubyExecutor):
     name = 'RUBY2'
-    command_paths = (['ruby2.%d' % i for i in reversed(range(0, 5))] +
-                     ['ruby2%d' % i for i in reversed(range(0, 5))])
+    command_paths = (['ruby2.%d' % i for i in reversed(range(0, 7))] +
+                     ['ruby2%d' % i for i in reversed(range(0, 7))])
     syscalls = ['pipe2', 'poll', 'thr_set_name']
     fs = ['/proc/self/loginuid$']
 

--- a/dmoj/executors/TUR.py
+++ b/dmoj/executors/TUR.py
@@ -16,16 +16,16 @@ put echo
         return super(Executor, self).get_fs() + [self._code + 'bc']
 
     def get_compile_args(self):
-        return [self.get_command(), self._code, env['runtime']['turing_dir']]
+        return [self.get_command(), self._code, '/opt/turing/']
 
     def get_cmdline(self):
-        return [env['runtime']['tprolog'], self._code + 'bc']
+        return ['/usr/local/bin/tprolog', self._code + 'bc']
 
     def get_executable(self):
         return None
 
     @classmethod
     def initialize(cls, sandbox=True):
-        if 'tprolog' not in env['runtime'] or 'tprologc' not in env['runtime'] or 'turing_dir' not in env['runtime']:
-            return False
+#        if 'tprolog' not in env['runtime'] or 'tprologc' not in env['runtime'] or 'turing_dir' not in env['runtime']:
+#            return False
         return super(Executor, cls).initialize(sandbox=sandbox)

--- a/dmoj/executors/gcc_executor.py
+++ b/dmoj/executors/gcc_executor.py
@@ -95,7 +95,7 @@ class GCCExecutor(CompiledExecutor):
 
     @classmethod
     def get_version_flags(cls, command):
-        return ['-dumpversion']
+        return ['--version']
 
     @classmethod
     def autoconfig_run_test(cls, result):


### PR DESCRIPTION
Documentation for the JS Shell can be found at https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell