### PR TITLE
Fix IE with Unicode in Java compile error output.

### DIFF
--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -222,7 +222,7 @@ class JavacExecutor(JavaExecutor):
         return [self.get_compiler(), '-Xlint', '-encoding', 'UTF-8', self._code]
 
     def handle_compile_error(self, output):
-        if b'is public, should be declared in a file named' in output:
+        if b'is public, should be declared in a file named' in utf8bytes(output):
             raise CompileError('You are a troll. Trolls are not welcome. '
                                'As a judge, I sentence your code to death.\n')
         raise CompileError(output)


### PR DESCRIPTION
In Python 3, having a compile error with Unicode in the output causes:
```
Traceback (most recent call last):
  File "/code/judge/dmoj/judge.py", line 276, in get_grader_from_source
    grader = grader_class(self, problem, language, utf8bytes(source))
  File "/code/judge/dmoj/graders/base.py", line 10, in __init__
    self.binary = self._generate_binary()
  File "/code/judge/dmoj/graders/standard.py", line 175, in _generate_binary
    unbuffered=self.problem.config.unbuffered)
  File "/code/judge/dmoj/executors/base_executor.py", line 314, in __call__
    obj.compile()
  File "/code/judge/dmoj/executors/base_executor.py", line 439, in compile
    self.handle_compile_error(output)
  File "/code/judge/dmoj/executors/java_executor.py", line 238, in handle_compile_error
    if b'is public, should be declared in a file named' in output:
TypeError: 'in <string>' requires string as left operand, not bytes
```