### PR TITLE
Remove pull-request event for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push, pull_request]
+on: push
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Looking through https://docs.github.com/en/actions/reference/events-that-trigger-workflows#configuring-workflow-events,, the pull request event gets triggered when certain things happen on a pull request, namely looks like opening one causes this.

Just `push` should be enough and I'd like to test it but sadly a little hard to do with workflows.